### PR TITLE
Add per-role retention overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 5.8  
 **Tested up to:** 6.5  
 **Requires PHP:** 7.4  
-**Stable tag:** 1.1.0  
+**Stable tag:** 1.2.0
 **License:** GPL-2.0-or-later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,7 @@ The Data Retention Policy Manager plugin allows site administrators to configure
   * Disabling inactive users.
   * Deleting users a set time after they have been disabled.
   * Archiving posts and pages after a chosen period.
+  * Overriding user retention policies for individual roles.
 * Daily cron task that processes users and content according to the configured rules.
 * Prevents disabled accounts from signing in and records when content is archived.
 * Adds retention status and last active columns to the user list and provides a quick action to re-enable accounts.
@@ -28,7 +29,7 @@ The Data Retention Policy Manager plugin allows site administrators to configure
 
 ### Configuration
 
-Durations can be expressed in days, months (30 days), or years (365 days). Leave any value at zero to disable that specific policy. User deletion requires that a disable duration is also set. All times are calculated based on the last recorded user activity (login) and the original publish date for posts and pages.
+Durations can be expressed in days, months (30 days), or years (365 days). Leave any value at zero to disable that specific policy. User deletion requires that a disable duration is also set. All times are calculated based on the last recorded user activity (login) and the original publish date for posts and pages. Role overrides inherit the default policy when left blank, letting you tailor retention windows per role.
 
 ### Filters
 
@@ -55,12 +56,19 @@ Yes. Use the `drp_excluded_roles` filter to add any roles that should be skipped
 
 ## Changelog
 
+### 1.2.0
+* Added role-specific overrides for user disable and delete policies.
+* Improved the settings UI to better communicate empty values.
+
 ### 1.1.0
 * Introduced cron-based automation for user and content retention workflows.
 * Added admin settings page with retention duration controls.
 * Added user list columns and quick actions for retention status.
 
 ## Upgrade Notice
+
+### 1.2.0
+Review your role-specific settings after updating to take advantage of the new per-role retention controls.
 
 ### 1.1.0
 Ensure your retention durations are configured after updating to take advantage of the new automation workflows.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: data-retention, privacy, gdpr, users, cron
 Requires at least: 5.8
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,13 +18,14 @@ The Data Retention Policy Manager plugin allows site administrators to configure
   * Disabling inactive users.
   * Deleting users a set time after they have been disabled.
   * Archiving posts and pages after a chosen period.
+  * Overriding user retention policies for individual roles.
 * Daily cron task that processes users and content according to the configured rules.
 * Prevents disabled accounts from signing in and records when content is archived.
 * Adds retention status and last active columns to the user list and provides a quick action to re-enable accounts.
 * Supports customisation through filters for excluded roles and batch sizes.
 
 = Configuration =
-Durations can be expressed in days, months (30 days), or years (365 days). Leave any value at zero to disable that specific policy. User deletion requires that a disable duration is also set. All times are calculated based on the last recorded user activity (login) and the original publish date for posts and pages.
+Durations can be expressed in days, months (30 days), or years (365 days). Leave any value at zero to disable that specific policy. User deletion requires that a disable duration is also set. All times are calculated based on the last recorded user activity (login) and the original publish date for posts and pages. Role overrides inherit the default user policy when left blank, letting you fine-tune retention windows for each role when needed.
 
 = Filters =
 * `drp_excluded_roles` — Modify the list of user roles excluded from retention processing. Defaults to `['administrator']`.
@@ -46,11 +47,18 @@ The retention policies focus on posts and pages. Custom post type support can be
 Yes. Use the `drp_excluded_roles` filter to add any roles that should be skipped during processing.
 
 == Changelog ==
+= 1.2.0 =
+* Added role-specific overrides for user disable and delete retention policies.
+* Improved settings UI with clearer empty state handling.
+
 = 1.1.0 =
 * Introduced cron-based automation for user and content retention workflows.
 * Added admin settings page with retention duration controls.
 * Added user list columns and quick actions for retention status.
 
 == Upgrade Notice ==
+= 1.2.0 =
+Review your role-specific settings after updating to take advantage of the new per-role retention controls.
+
 = 1.1.0 =
 Ensure your retention durations are configured after updating to take advantage of the new automation workflows.


### PR DESCRIPTION
## Summary
- add admin controls to configure per-role disable/delete retention windows
- update background processing to honour role-specific overrides while keeping default policies
- document the new capability and bump the plugin version to 1.2.0

## Testing
- php -l data-retention-policy.php

------
https://chatgpt.com/codex/tasks/task_b_68dcf719ab6883258294649ba22b0603